### PR TITLE
[POM-19] Define go structs for websocket messaging/webrtc signaling

### DIFF
--- a/internal/webrtc_signaling/messages.go
+++ b/internal/webrtc_signaling/messages.go
@@ -1,1 +1,22 @@
 package webrtc_signaling
+
+// Generic structure for messages exchanged over Web
+type WebSocketMessage struct {
+	Type string `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+// Structure for messages exchanged over WebRTC Signaling Channel
+type SignalMessagePayload struct {
+	SignalType string `json:"signal_type"`
+	SDP string `json:"sdp,omitempty"`
+	Candidate *ICECandidate `json:"candidate,omitempty"`
+	TargetUserID string `json:"targetUserID"`
+}
+
+// Structure for ICE Candidates
+type ICECandidate struct {
+	Candidate string `json:"candidate"`
+	SDMPid string `json:"sdpMid"`
+	SDMPLineIndex uint16 `json:"sdpMLineIndex"`
+}


### PR DESCRIPTION

##  [POM-19] Define go structs for websocket messaging/webrtc signalling

**Description:**

The following PR defines go structs for messaging/signalling, which may be updated as we make more changes

https://pomodoio.atlassian.net/browse/POM-19

**Some Context:**

WebRTC signalling messages are typically exchanged as JSON objects. 

- We have defined the structure of these JSON objects using structs. 
- The encoding/json package in Go can then automatically convert the Go structs into JSON and parse incoming JSON into these Go structs (as long as the struct tags are accurate)

_What are Struct Tags?_ 

Small strings added to struct fields (e.g., json:"fieldName"). They tell the encoding/json package and other Go libraries, how to map struct fields to keys in the JSON output/input.

**Type of Change:**
(Select one)
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

**Key Changes:**
N/A

**How to Test:**
N/A