### PR TITLE
[POM-20] Room management POC for testing (until we implement actual room management)

### DIFF
--- a/internal/webrtc_signaling/signaler.go
+++ b/internal/webrtc_signaling/signaler.go
@@ -1,1 +1,94 @@
 package webrtc_signaling
+
+import (
+	"fmt" 
+	"sync" 
+)
+
+type Signaler struct {
+	// maps room ID to a list of user IDs
+	rooms map[string][]string
+
+	// mutex to protect the map from concurrent access
+	mu sync.Mutex
+}
+
+// NewSignaler for new Signaler instance.
+func NewSignaler() *Signaler {
+	// Initialize map
+	return &Signaler{
+		rooms: make(map[string][]string),
+	}
+}
+
+func (s *Signaler) AddUserToRoom(roomID string, userID string) {
+	s.mu.Lock() 
+	defer s.mu.Unlock() // Release the lock when the function exits
+
+	users, exists := s.rooms[roomID]
+	if !exists {
+		// If does not exist, create the room with the first user
+		s.rooms[roomID] = []string{userID}
+		fmt.Printf("Room %s created, user %s joined.\n", roomID, userID)
+		return
+	}
+
+	// Check if the user is already in the room
+	for _, existingUser := range users {
+		if existingUser == userID {
+			fmt.Printf("User %s is already in room %s.\n", userID, roomID)
+			return
+		}
+	}
+
+	// Add the user to the existing room
+	s.rooms[roomID] = append(users, userID)
+	fmt.Printf("User %s joined room %s. Current users: %v\n", userID, roomID, s.rooms[roomID])
+}
+
+// RemoveUserFromRoom removes a user from the specified simulated room.
+func (s *Signaler) RemoveUserFromRoom(roomID string, userID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	users, exists := s.rooms[roomID]
+	if !exists {
+		// Room doesn't exist, nothing to remove
+		fmt.Printf("Attempted to remove user %s from non-existent room %s.\n", userID, roomID)
+		return
+	}
+
+	// Find and remove the user from the slice
+	newUsers := []string{}
+	for _, existingUser := range users {
+		if existingUser != userID {
+			newUsers = append(newUsers, existingUser)
+		}
+	}
+
+	s.rooms[roomID] = newUsers
+	fmt.Printf("User %s left room %s. Remaining users: %v\n", userID, roomID, s.rooms[roomID])
+
+	// Optional: Clean up the room if it's empty
+	if len(s.rooms[roomID]) == 0 {
+		delete(s.rooms, roomID)
+		fmt.Printf("Room %s is now empty and has been removed.\n", roomID)
+	}
+}
+
+// GetUsersInRoom returns a slice of user IDs in the specified simulated room.
+// Returns an empty slice and false if the room does not exist.
+func (s *Signaler) GetUsersInRoom(roomID string) ([]string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	users, exists := s.rooms[roomID]
+	if !exists {
+		return []string{}, false
+	}
+
+	// Return a copy of the slice to prevent external modification of the internal map
+	usersCopy := make([]string, len(users))
+	copy(usersCopy, users)
+	return usersCopy, true
+}

--- a/internal/webrtc_signaling/signaler_test.go
+++ b/internal/webrtc_signaling/signaler_test.go
@@ -1,0 +1,132 @@
+package webrtc_signaling
+
+import (
+	"reflect" // Useful for comparing slices or structs
+	"sort"    // Good for comparing slices regardless of order
+	"testing"
+)
+
+func TestSignaler_AddUserToRoom(t *testing.T) {
+	s := NewSignaler() // Create a new signaler instance for each test
+
+	roomID := "room123"
+	userID1 := "userA"
+	userID2 := "userB"
+
+	// Test adding the first user
+	s.AddUserToRoom(roomID, userID1)
+	users, exists := s.GetUsersInRoom(roomID)
+	if !exists {
+		t.Errorf("Expected room %s to exist after adding user, but it doesn't", roomID)
+	}
+	expectedUsers1 := []string{userID1}
+	// Sort slices before comparison if order doesn't matter
+	sort.Strings(users)
+	sort.Strings(expectedUsers1)
+	if !reflect.DeepEqual(users, expectedUsers1) {
+		t.Errorf("Expected users in room %s to be %v, but got %v", roomID, expectedUsers1, users)
+	}
+
+	// Test adding a second user to the same room
+	s.AddUserToRoom(roomID, userID2)
+	users, exists = s.GetUsersInRoom(roomID)
+	if !exists {
+		t.Errorf("Expected room %s to still exist after adding second user, but it doesn't", roomID)
+	}
+	expectedUsers2 := []string{userID1, userID2}
+	sort.Strings(users)
+	sort.Strings(expectedUsers2)
+	if !reflect.DeepEqual(users, expectedUsers2) {
+		t.Errorf("Expected users in room %s to be %v, but got %v", roomID, expectedUsers2, users)
+	}
+
+	// Test adding the same user again (should not change anything)
+	s.AddUserToRoom(roomID, userID1)
+	users, exists = s.GetUsersInRoom(roomID)
+	if !exists {
+		t.Errorf("Expected room %s to still exist after adding same user, but it doesn't", roomID)
+	}
+	sort.Strings(users)
+	if !reflect.DeepEqual(users, expectedUsers2) { // Still expect the same users
+		t.Errorf("Expected users in room %s to still be %v after adding same user, but got %v", roomID, expectedUsers2, users)
+	}
+}
+
+func TestSignaler_RemoveUserFromRoom(t *testing.T) {
+	s := NewSignaler()
+
+	roomID := "room456"
+	userID1 := "userX"
+	userID2 := "userY"
+	userID3 := "userZ"
+
+	// Set up the room with multiple users
+	s.AddUserToRoom(roomID, userID1)
+	s.AddUserToRoom(roomID, userID2)
+	s.AddUserToRoom(roomID, userID3)
+
+	// Test removing a user
+	s.RemoveUserFromRoom(roomID, userID2)
+	users, exists := s.GetUsersInRoom(roomID)
+	if !exists {
+		t.Errorf("Expected room %s to exist after removing one user, but it doesn't", roomID)
+	}
+	expectedUsers1 := []string{userID1, userID3}
+	sort.Strings(users)
+	sort.Strings(expectedUsers1)
+	if !reflect.DeepEqual(users, expectedUsers1) {
+		t.Errorf("Expected users in room %s to be %v after removing %s, but got %v", roomID, expectedUsers1, userID2, users)
+	}
+
+	// Test removing the last user
+	s.RemoveUserFromRoom(roomID, userID1)
+	s.RemoveUserFromRoom(roomID, userID3)
+	_, exists = s.GetUsersInRoom(roomID)
+	if exists {
+		t.Errorf("Expected room %s to be removed after removing all users, but it still exists", roomID)
+	}
+
+	// Test removing a user from a non-existent room (should do nothing and not panic)
+	s.RemoveUserFromRoom("nonExistentRoom", "someUser")
+
+	// Test removing a user who is not in the room (should not change anything)
+	s = NewSignaler() // Reset for this specific test
+	s.AddUserToRoom(roomID, userID1)
+	s.RemoveUserFromRoom(roomID, "nonExistentUser")
+	users, exists = s.GetUsersInRoom(roomID)
+	if !exists || len(users) != 1 || users[0] != userID1 {
+		t.Errorf("Removing non-existent user changed the room state unexpectedly. Expected [%s], got %v, exists: %t", userID1, users, exists)
+	}
+}
+
+func TestSignaler_GetUsersInRoom(t *testing.T) {
+	s := NewSignaler()
+	roomID := "room789"
+	userIDs := []string{"userM", "userN", "userO"}
+
+	// Test getting users from a non-existent room
+	users, exists := s.GetUsersInRoom("nonExistentRoom")
+	if exists {
+		t.Errorf("Expected non-existent room to not exist, but it does")
+	}
+	if len(users) != 0 {
+		t.Errorf("Expected empty slice for non-existent room, but got %v", users)
+	}
+
+	// Add users to the room
+	for _, userID := range userIDs {
+		s.AddUserToRoom(roomID, userID)
+	}
+
+	// Test getting users from an existing room
+	users, exists = s.GetUsersInRoom(roomID)
+	if !exists {
+		t.Errorf("Expected room %s to exist, but it doesn't", roomID)
+	}
+	expectedUsers := userIDs
+	sort.Strings(users)
+	sort.Strings(expectedUsers)
+	if !reflect.DeepEqual(users, expectedUsers) {
+		t.Errorf("Expected users %v for room %s, but got %v", expectedUsers, roomID, users)
+	}
+}


### PR DESCRIPTION
##  [POM-19] Define go structs for websocket messaging/webrtc signalling

**Description:**

The following PR defines a room management simulation for testing and added a new test. 

To run the test, cd into `internal/webrtc_signaling` and run `go test`

Keeping description short for now.

**Type of Change:**
(Select one)
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

**Key Changes:**
N/A

**How to Test:**
N/A